### PR TITLE
Day of Week Support and UI Improvements

### DIFF
--- a/.github/workflows/pipeline-build.yml
+++ b/.github/workflows/pipeline-build.yml
@@ -3,8 +3,6 @@ name: Build
 on:
   workflow_dispatch:
   push:
-    branches:
-      - feature/sts_jobs
 
 concurrency:
   # One build per PR, do not cancel builds on main

--- a/.github/workflows/pipeline-build.yml
+++ b/.github/workflows/pipeline-build.yml
@@ -77,6 +77,7 @@ jobs:
           git clone --branch gh-pages https://github.com/${{ github.repository_owner }}/drowzee.git existing-charts || true
           mkdir -p packaged-charts
 
+          # If main branch, we need to remove all dev versions
           if [[ "${GITHUB_REF##*/}" == "main" ]]; then
             for file in existing-charts/*; do
               if [[ ! $(basename "$file") == drowzee-${{ needs.generate-version.outputs.chart-version }}-* ]]; then
@@ -85,6 +86,12 @@ jobs:
             done
           else
             cp -n existing-charts/*.tgz packaged-charts/ || true
+          fi
+
+          # Validate that release version is not exist
+          if [[ -e "existing-charts/drowzee-${{ needs.generate-version.outputs.chart-version }}.tgz" ]]; then
+            echo "Error: Release version ${needs.generate-version.outputs.chart-version} already exists"
+            exit 1
           fi
       - name: Set up Helm
         uses: azure/setup-helm@v4

--- a/chart/crds/sleepschedule.yaml
+++ b/chart/crds/sleepschedule.yaml
@@ -109,6 +109,10 @@ spec:
           type: string
           description: Enabled
           jsonPath: .spec.enabled
+        - name: DayOfWeek
+          type: string
+          description: Active Days
+          jsonPath: .spec.dayOfWeek
         - name: SleepTime
           type: string
           description: Starts Sleeping
@@ -146,7 +150,6 @@ spec:
           description: Status overridden by user
           jsonPath: .status.conditions[?(@.type == "ManualOverride")].status
       served: true
-      deprecationWarning: ""
 metadata:
   name: sleepschedules.drowzee.challengr.io
   labels:

--- a/chart/crds/sleepschedule.yaml
+++ b/chart/crds/sleepschedule.yaml
@@ -99,10 +99,14 @@ spec:
                 wakeTime:
                   type: string
                   description: "The time that the deployment will wake up (format: HH:MMam/pm)"
+                dayOfWeek:
+                  type: string
+                  description: "Cron-like expression for days of the week when the schedule is active (0-6 or SUN-SAT). Examples: '1-5' for weekdays, '0,6' for weekends, '*' for all days (default)."
+                  default: "*"
       storage: true
       additionalPrinterColumns:
         - name: Enabled
-          type: boolean
+          type: string
           description: Enabled
           jsonPath: .spec.enabled
         - name: SleepTime
@@ -142,7 +146,7 @@ spec:
           description: Status overridden by user
           jsonPath: .status.conditions[?(@.type == "ManualOverride")].status
       served: true
-      deprecationWarning:
+      deprecationWarning: ""
 metadata:
   name: sleepschedules.drowzee.challengr.io
   labels:

--- a/lib/drowzee/sleep_checker.ex
+++ b/lib/drowzee/sleep_checker.ex
@@ -1,36 +1,86 @@
 defmodule Drowzee.SleepChecker do
   require Logger
 
-  def naptime?(_sleep_time, nil, _timezone) do
+  # Define the function head with default value
+  def naptime?(sleep_time, wake_time, timezone, day_of_week \\ "*")
+
+  def naptime?(_sleep_time, nil, _timezone, _day_of_week) do
     # If wake_time is nil, always consider it naptime (always sleeping)
     Logger.debug("Wake time is not defined, resources will remain scaled down/suspended indefinitely")
     {:ok, true}
   end
 
-  def naptime?(sleep_time, "", timezone) do
+  def naptime?(sleep_time, "", timezone, day_of_week) do
     # Empty string wake_time is treated the same as nil
-    naptime?(sleep_time, nil, timezone)
+    naptime?(sleep_time, nil, timezone, day_of_week)
   end
 
-  def naptime?(sleep_time, wake_time, timezone) do
+  def naptime?(sleep_time, wake_time, timezone, day_of_week) do
     now = DateTime.now!(timezone)
     today_date = DateTime.to_date(now)
 
-    with {:ok, sleep_datetime} <- parse_time(sleep_time, today_date, timezone),
-         {:ok, wake_datetime} <- parse_time(wake_time, today_date, timezone) do
-      Logger.debug("Sleep time: #{format(sleep_datetime, "{h24}:{m}:{s}")}, Wake time: #{format(wake_datetime, "{h24}:{m}:{s}")}, Now: #{format(now)}")
-      result = case DateTime.compare(sleep_datetime, wake_datetime) do
-          :gt ->
-            DateTime.compare(now, sleep_datetime) in [:eq, :gt] or DateTime.compare(now, wake_datetime) == :lt
-          :lt ->
-            DateTime.compare(now, sleep_datetime) in [:eq, :gt] and DateTime.compare(now, wake_datetime) == :lt
-          :eq ->
-            Logger.warning("Sleep time and wake time cannot be the same!")
-            false
-        end
-      {:ok, result}
+    # Check if schedule is active today based on day of week
+    is_active_today = day_of_week_matches?(now, day_of_week)
+
+    if not is_active_today do
+      # If today is not an active day, do nothing (maintain current state)
+      dow_num = Date.day_of_week(today_date)
+      dow_name = Timex.day_name(dow_num)
+      Logger.debug("Today (#{dow_num}/#{dow_name}) is not in day of week expression '#{day_of_week}', maintaining current state")
+      {:ok, :inactive_day}
     else
-      {:error, error} -> {:error, error}
+      with {:ok, sleep_datetime} <- parse_time(sleep_time, today_date, timezone),
+           {:ok, wake_datetime} <- parse_time(wake_time, today_date, timezone) do
+        Logger.debug("Sleep time: #{format(sleep_datetime, "{h24}:{m}:{s}")}, Wake time: #{format(wake_datetime, "{h24}:{m}:{s}")}, Now: #{format(now)}")
+        result = case DateTime.compare(sleep_datetime, wake_datetime) do
+            :gt ->
+              DateTime.compare(now, sleep_datetime) in [:eq, :gt] or DateTime.compare(now, wake_datetime) == :lt
+            :lt ->
+              DateTime.compare(now, sleep_datetime) in [:eq, :gt] and DateTime.compare(now, wake_datetime) == :lt
+            :eq ->
+              Logger.warning("Sleep time and wake time cannot be the same!")
+              false
+          end
+        {:ok, result}
+      else
+        {:error, error} -> {:error, error}
+      end
+    end
+  end
+
+  # Check if the current day of week matches the cron-like expression
+  # Examples:
+  # "*" - all days (default)
+  # "1-5" - Monday to Friday
+  # "0,6" - Sunday and Saturday
+  # "MON-FRI" - Monday to Friday
+  # "SUN,SAT" - Sunday and Saturday
+  defp day_of_week_matches?(_now, nil), do: true
+  defp day_of_week_matches?(_now, ""), do: true
+  defp day_of_week_matches?(_now, "*"), do: true
+  defp day_of_week_matches?(now, day_of_week) do
+    # Convert Elixir's Date.day_of_week (1-7, Monday is 1) to Crontab's format (0-6, Sunday is 0)
+    dow_num = Date.day_of_week(now)
+    _cron_dow = if dow_num == 7, do: 0, else: dow_num
+
+    # Create a full cron expression with the day of week part
+    # The format is: minute hour day month day_of_week
+    cron_expression = "* * * * #{day_of_week}"
+
+    # Parse the cron expression and check if it matches the current day
+    case Crontab.CronExpression.Parser.parse(cron_expression) do
+      {:ok, cron_expression} ->
+        # Create a NaiveDateTime struct for matching (required by Crontab.DateChecker.matches_date?)
+        naive_datetime = NaiveDateTime.new!(now.year, now.month, now.day, 0, 0, 0)
+
+        # Check if the current day of week matches the expression
+        # We only care about the day of week part, not the full date match
+        Crontab.DateChecker.matches_date?(cron_expression, naive_datetime)
+
+      {:error, error} ->
+        # Log the error and default to true (all days) for invalid expressions
+        Logger.error("Invalid cron expression for day of week: #{day_of_week}. Error: #{inspect(error)}")
+        true
     end
   end
 

--- a/lib/drowzee/sleep_checker.ex
+++ b/lib/drowzee/sleep_checker.ex
@@ -61,8 +61,31 @@ defmodule Drowzee.SleepChecker do
   defp day_of_week_matches?(now, day_of_week) do
     # Convert Elixir's Date.day_of_week (1-7, Monday is 1) to Crontab's format (0-6, Sunday is 0)
     dow_num = Date.day_of_week(now)
-    _cron_dow = if dow_num == 7, do: 0, else: dow_num
-
+    cron_dow = if dow_num == 7, do: 0, else: dow_num
+    
+    # Log the current day for debugging
+    Logger.debug("Current day: #{now.day}, dow_num: #{dow_num}, cron_dow: #{cron_dow}")
+    
+    # Handle text-based day of week expressions (MON, TUE, etc.)
+    day_of_week = cond do
+      # If it's already a numeric expression, keep it as is
+      String.match?(day_of_week, ~r/^[0-9,\-*]+$/) -> 
+        day_of_week
+      # Otherwise, convert text days to numbers
+      true ->
+        day_of_week
+        |> String.upcase()
+        |> String.replace("SUN", "0")
+        |> String.replace("MON", "1")
+        |> String.replace("TUE", "2")
+        |> String.replace("WED", "3")
+        |> String.replace("THU", "4")
+        |> String.replace("FRI", "5")
+        |> String.replace("SAT", "6")
+    end
+    
+    Logger.debug("Checking if day #{cron_dow} matches expression: #{day_of_week}")
+    
     # Create a full cron expression with the day of week part
     # The format is: minute hour day month day_of_week
     cron_expression = "* * * * #{day_of_week}"

--- a/lib/drowzee_web/live/home_live/index.ex
+++ b/lib/drowzee_web/live/home_live/index.ex
@@ -264,7 +264,7 @@ defmodule DrowzeeWeb.HomeLive.Index do
 
   def format_day_of_week(day_of_week) do
     cond do
-      day_of_week == "*" ->
+      day_of_week in ["*", "", nil] ->
         "ALL DAYS"
       String.match?(day_of_week, ~r/^\d/) ->
         # Handle numeric format (0,6 or 1-5)

--- a/lib/drowzee_web/live/home_live/index.ex
+++ b/lib/drowzee_web/live/home_live/index.ex
@@ -262,6 +262,34 @@ defmodule DrowzeeWeb.HomeLive.Index do
       |> Timex.format!("{h12}:{m}{am}")
   end
 
+  def format_day_of_week(day_of_week) do
+    cond do
+      day_of_week == "*" ->
+        "ALL DAYS"
+      String.match?(day_of_week, ~r/^\d/) ->
+        # Handle numeric format (0,6 or 1-5)
+        day_of_week
+        |> String.split([",", "-"])
+        |> Enum.map(fn d ->
+          case d do
+            "0" -> "SUN"
+            "1" -> "MON"
+            "2" -> "TUE"
+            "3" -> "WED"
+            "4" -> "THU"
+            "5" -> "FRI"
+            "6" -> "SAT"
+            _ -> d
+          end
+        end)
+        |> Enum.join(", ")
+        |> String.replace(", ", "-", global: false)
+      true ->
+        # Handle text format (MON-FRI or SUN,SAT)
+        String.upcase(day_of_week)
+    end
+  end
+
   def replace_sleep_schedule(socket, updated_sleep_schedule) do
     sleep_schedules = Enum.map(socket.assigns.sleep_schedules, fn sleep_schedule ->
       if sleep_schedule["metadata"]["name"] == updated_sleep_schedule["metadata"]["name"] && sleep_schedule["metadata"]["namespace"] == updated_sleep_schedule["metadata"]["namespace"] do

--- a/lib/drowzee_web/live/home_live/index.html.heex
+++ b/lib/drowzee_web/live/home_live/index.html.heex
@@ -238,28 +238,38 @@
 
           <div class="text-gray-600 mt-4">
             🕒 <strong>Schedule:</strong>
-            <div class="mt-2 ml-6 grid grid-cols-2 gap-x-2 gap-y-1">
-              <div class="text-gray-700 font-medium">DayOfWeek:</div>
-              <div>
-                <span class="px-2 py-0.5 bg-blue-100 text-blue-800 rounded-full text-xs">
-                  📅 {format_day_of_week(sleep_schedule["spec"]["dayOfWeek"] || "*")}
+            <div class="mt-2 ml-6 bg-gray-50 p-3 rounded-lg border border-gray-200 shadow-sm">
+              <div class="flex items-center mb-2">
+                <span class="px-2 py-0.5 bg-blue-100 text-blue-800 rounded-full text-xs mr-2">
+                  📅 {format_day_of_week(sleep_schedule["spec"]["dayOfWeek"])}
+                </span>
+                <span class="text-gray-500 text-sm">Active days</span>
+              </div>
+              
+              <div class="flex items-center mb-2">
+                <span class="font-medium text-gray-700 mr-2">Sleep at:</span>
+                <span class="px-2 py-0.5 bg-blue-50 text-blue-700 rounded-md">
+                  {sleep_schedule["spec"]["sleepTime"]}
                 </span>
               </div>
-
-              <div class="text-gray-700 font-medium">SleepTime:</div>
-              <div>{sleep_schedule["spec"]["sleepTime"]}</div>
-
-              <div class="text-gray-700 font-medium">WakeTime:</div>
-              <div>
+              
+              <div class="flex items-center mb-2">
+                <span class="font-medium text-gray-700 mr-2">Wake at:</span>
                 <%= if sleep_schedule["spec"]["wakeTime"] do %>
-                  {sleep_schedule["spec"]["wakeTime"]}
+                  <span class="px-2 py-0.5 bg-green-50 text-green-700 rounded-md">
+                    {sleep_schedule["spec"]["wakeTime"]}
+                  </span>
                 <% else %>
-                  <span class="text-red-600 font-semibold">MANUAL ONLY</span>
+                  <span class="px-2 py-0.5 bg-red-50 text-red-700 rounded-md font-medium">
+                    MANUAL ONLY
+                  </span>
                 <% end %>
               </div>
-
-              <div class="text-gray-700 font-medium">TimeZone:</div>
-              <div>{sleep_schedule["spec"]["timezone"]}</div>
+              
+              <div class="flex items-center">
+                <span class="font-medium text-gray-700 mr-2">Time zone:</span>
+                <span class="text-gray-600">{sleep_schedule["spec"]["timezone"]}</span>
+              </div>
             </div>
           </div>
 

--- a/lib/drowzee_web/live/home_live/index.html.heex
+++ b/lib/drowzee_web/live/home_live/index.html.heex
@@ -242,6 +242,11 @@
               {sleep_schedule["spec"]["sleepTime"]} - {sleep_schedule["spec"]["wakeTime"]} ({sleep_schedule[
                 "spec"
               ]["timezone"]})
+              <%= if sleep_schedule["spec"]["dayOfWeek"] && sleep_schedule["spec"]["dayOfWeek"] != "*" do %>
+                <span class="ml-2 px-2 py-0.5 bg-blue-100 text-blue-800 rounded-full text-xs">
+                  📅 {sleep_schedule["spec"]["dayOfWeek"]}
+                </span>
+              <% end %>
             </span>
           </div>
 

--- a/lib/drowzee_web/live/home_live/index.html.heex
+++ b/lib/drowzee_web/live/home_live/index.html.heex
@@ -238,16 +238,29 @@
 
           <div class="text-gray-600 mt-4">
             🕒 <strong>Schedule:</strong>
-            <span>
-              {sleep_schedule["spec"]["sleepTime"]} - {sleep_schedule["spec"]["wakeTime"]} ({sleep_schedule[
-                "spec"
-              ]["timezone"]})
-              <%= if sleep_schedule["spec"]["dayOfWeek"] && sleep_schedule["spec"]["dayOfWeek"] != "*" do %>
-                <span class="ml-2 px-2 py-0.5 bg-blue-100 text-blue-800 rounded-full text-xs">
-                  📅 {sleep_schedule["spec"]["dayOfWeek"]}
+            <div class="mt-2 ml-6 grid grid-cols-2 gap-x-2 gap-y-1">
+              <div class="text-gray-700 font-medium">DayOfWeek:</div>
+              <div>
+                <span class="px-2 py-0.5 bg-blue-100 text-blue-800 rounded-full text-xs">
+                  📅 {format_day_of_week(sleep_schedule["spec"]["dayOfWeek"] || "*")}
                 </span>
-              <% end %>
-            </span>
+              </div>
+
+              <div class="text-gray-700 font-medium">SleepTime:</div>
+              <div>{sleep_schedule["spec"]["sleepTime"]}</div>
+
+              <div class="text-gray-700 font-medium">WakeTime:</div>
+              <div>
+                <%= if sleep_schedule["spec"]["wakeTime"] do %>
+                  {sleep_schedule["spec"]["wakeTime"]}
+                <% else %>
+                  <span class="text-red-600 font-semibold">MANUAL ONLY</span>
+                <% end %>
+              </div>
+
+              <div class="text-gray-700 font-medium">TimeZone:</div>
+              <div>{sleep_schedule["spec"]["timezone"]}</div>
+            </div>
           </div>
 
           <%= if get_condition(sleep_schedule, "ManualOverride")["status"] == "True" do %>

--- a/mix.exs
+++ b/mix.exs
@@ -57,7 +57,8 @@ defmodule Drowzee.MixProject do
       {:dns_cluster, "~> 0.1.1"},
       {:bandit, "~> 1.5"},
       {:bonny, "~> 1.0"},
-      {:timex, "~> 3.7"}
+      {:timex, "~> 3.7"},
+      {:crontab, "~> 1.1"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -4,6 +4,7 @@
   "castore": {:hex, :castore, "1.0.12", "053f0e32700cbec356280c0e835df425a3be4bc1e0627b714330ad9d0f05497f", [:mix], [], "hexpm", "3dca286b2186055ba0c9449b4e95b97bf1b57b47c1f2644555879e659960c224"},
   "certifi": {:hex, :certifi, "2.14.0", "ed3bef654e69cde5e6c022df8070a579a79e8ba2368a00acf3d75b82d9aceeed", [:rebar3], [], "hexpm", "ea59d87ef89da429b8e905264fdec3419f84f2215bb3d81e07a18aac919026c3"},
   "combine": {:hex, :combine, "0.10.0", "eff8224eeb56498a2af13011d142c5e7997a80c8f5b97c499f84c841032e429f", [:mix], [], "hexpm", "1b1dbc1790073076580d0d1d64e42eae2366583e7aecd455d1215b0d16f2451b"},
+  "crontab": {:hex, :crontab, "1.1.14", "233fcfdc2c74510cabdbcb800626babef414e7cb13cea11ddf62e10e16e2bf76", [:mix], [{:ecto, "~> 1.0 or ~> 2.0 or ~> 3.0", [hex: :ecto, repo: "hexpm", optional: true]}], "hexpm", "4e3b9950bc22ae8d0395ffb5f4b127a140005cba95745abf5ff9ee7e8203c6fa"},
   "dns_cluster": {:hex, :dns_cluster, "0.1.3", "0bc20a2c88ed6cc494f2964075c359f8c2d00e1bf25518a6a6c7fd277c9b0c66", [:mix], [], "hexpm", "46cb7c4a1b3e52c7ad4cbe33ca5079fbde4840dedeafca2baf77996c2da1bc33"},
   "esbuild": {:hex, :esbuild, "0.9.0", "f043eeaca4932ca8e16e5429aebd90f7766f31ac160a25cbd9befe84f2bc068f", [:mix], [{:jason, "~> 1.4", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "b415027f71d5ab57ef2be844b2a10d0c1b5a492d431727f43937adce22ba45ae"},
   "expo": {:hex, :expo, "1.1.0", "f7b9ed7fb5745ebe1eeedf3d6f29226c5dd52897ac67c0f8af62a07e661e5c75", [:mix], [], "hexpm", "fbadf93f4700fb44c331362177bdca9eeb8097e8b0ef525c9cc501cb9917c960"},

--- a/sleep_schedule.yaml
+++ b/sleep_schedule.yaml
@@ -1,10 +1,11 @@
 apiVersion: drowzee.challengr.io/v1beta1
 kind: SleepSchedule
 metadata:
-  name: testing
+  name: working-hours
 spec:
   sleepTime: "10:00pm"
   wakeTime: "09:00am"
+  dayOfWeek: "mon-fri"
   timezone: "Australia/Sydney"
   deployments:
     - name: dummy-service
@@ -13,38 +14,26 @@ spec:
 apiVersion: drowzee.challengr.io/v1beta1
 kind: SleepSchedule
 metadata:
-  name: service1
-  namespace: services
+  name: every-day
 spec:
   sleepTime: "10:00pm"
   wakeTime: "09:00am"
+  dayOfWeek: "*"
   timezone: "Australia/Sydney"
   deployments:
     - name: service1
     - name: service1-worker
+  cronjobs:
+    - name: service1-backup
   ingressName: service1
 ---
 apiVersion: drowzee.challengr.io/v1beta1
 kind: SleepSchedule
 metadata:
-  name: service2
-  namespace: services
-spec:
-  sleepTime: "10:00pm"
-  wakeTime: "09:00am"
-  timezone: "Australia/Sydney"
-  deployments:
-    - name: service2
-    - name: service2-worker
-  ingressName: service2
----
-apiVersion: drowzee.challengr.io/v1beta1
-kind: SleepSchedule
-metadata:
   name: permanent-down
-  namespace: services
 spec:
   sleepTime: "08:00pm"
+  dayOfWeek: "*"
   # No wakeTime defined - resources will remain scaled down indefinitely
   timezone: "Australia/Sydney"
   deployments:


### PR DESCRIPTION
## New Features

### Day of Week Support
- Added new day of week functionality to allow scheduling based on specific days
- Implemented support for both numeric (0-6) and text-based (SUN-SAT) formats
- Added ability to use ranges (MON-FRI) or comma-separated lists (SAT,SUN)
- Enhanced the sleep checker to skip schedules on non-active days
- Added detailed logging for day of week matching to aid in troubleshooting

### UI Enhancements
- Added day of week to CRD display fields for better visibility in kubectl output
- Redesigned schedule display in the web UI with a more intuitive block layout
- Added visual indicators for different schedule components:
  - Day of week shown as a blue badge
  - Sleep time shown in a light blue badge
  - Wake time shown in a green badge (or red "MANUAL ONLY" for permanent down schedules)
  - Time zone shown in plain text
- Added helper function to format day of week expressions consistently in UI

## Improvements

### Permanent Down Schedules (No Wake Time)
- Enhanced handling of schedules with no wake time to respect day of week settings
- Improved behavior to only scale down after sleep time on active days
- Added better logging for schedules with no wake time

### Code Quality
- Fixed contract violation in `Timex.day_name/1` call by passing the correct parameter type
- Improved error handling throughout the codebase
- Enhanced code comments for better maintainability
- Standardized handling of nil, empty string, and "*" values for day of week

## Bug Fixes
- Fixed issue where permanent down schedules would immediately scale down apps on active days instead of waiting for sleep time
- Ensured consistent behavior between schedules with and without wake times

## Technical Details
- The day of week functionality is implemented using the Crontab library for expression parsing
- Day of week expressions are converted to the appropriate format for the Crontab library
- The UI displays day of week in a user-friendly format with abbreviated day names
- Schedules with no wake time now properly maintain current state on non-active days