### PR TITLE
Add Support for 24-hour Time Format

### DIFF
--- a/chart/crds/sleepschedule.yaml
+++ b/chart/crds/sleepschedule.yaml
@@ -92,13 +92,13 @@ spec:
                   description: The ingress that will be slept/woken.
                 sleepTime:
                   type: string
-                  description: "The time that the deployment will start sleeping(format: HH:MMam/pm)"
+                  description: "The time that the deployment will start sleeping (format: HH:MM for 24h or H:MMam/pm for 12h)"
                 timezone:
                   type: string
                   description: The timezone that the input times are based in
                 wakeTime:
                   type: string
-                  description: "The time that the deployment will wake up (format: HH:MMam/pm)"
+                  description: "The time that the deployment will wake up (format: HH:MM for 24h or H:MMam/pm for 12h)"
                 dayOfWeek:
                   type: string
                   description: "Cron-like expression for days of the week when the schedule is active (0-6 or SUN-SAT). Examples: '1-5' for weekdays, '0,6' for weekends, '*' for all days (default)."

--- a/lib/drowzee/sleep_checker.ex
+++ b/lib/drowzee/sleep_checker.ex
@@ -129,12 +129,20 @@ defmodule Drowzee.SleepChecker do
   end
 
   defp parse_time(time_str, date, timezone) do
-    case Timex.parse(time_str, "%-I:%M%p", :strftime) do
+    # Try 24-hour format first (HH:MM)
+    case Timex.parse(time_str, "%H:%M", :strftime) do
       {:ok, time} ->
         datetime = DateTime.new!(date, Time.new!(time.hour, time.minute, 0), timezone)
         {:ok, datetime}
-      {:error, error} ->
-        {:error, error}
+      {:error, _} ->
+        # Fall back to 12-hour format with AM/PM (H:MMAM/PM)
+        case Timex.parse(time_str, "%-I:%M%p", :strftime) do
+          {:ok, time} ->
+            datetime = DateTime.new!(date, Time.new!(time.hour, time.minute, 0), timezone)
+            {:ok, datetime}
+          {:error, error} ->
+            {:error, error}
+        end
     end
   end
 

--- a/sleep_schedule.yaml
+++ b/sleep_schedule.yaml
@@ -30,6 +30,22 @@ spec:
 apiVersion: drowzee.challengr.io/v1beta1
 kind: SleepSchedule
 metadata:
+  name: 24h-format
+spec:
+  sleepTime: "22:00"
+  wakeTime: "09:00"
+  dayOfWeek: "*"
+  timezone: "Australia/Sydney"
+  deployments:
+    - name: service2
+    - name: service2-worker
+  cronjobs:
+    - name: service2-backup
+  ingressName: service2
+---
+apiVersion: drowzee.challengr.io/v1beta1
+kind: SleepSchedule
+metadata:
   name: permanent-down
 spec:
   sleepTime: "08:00pm"

--- a/test/drowzee/sleep_checker_test.exs
+++ b/test/drowzee/sleep_checker_test.exs
@@ -2,10 +2,28 @@ defmodule Drowzee.SleepCheckerTest do
   @moduledoc false
   use ExUnit.Case, async: false
 
-  test "parses a valid time" do
+  test "parses a valid time in 12-hour format" do
     assert {:ok, %DateTime{}} = Drowzee.SleepChecker.parse_time("12:00am", "Australia/Sydney")
     assert {:ok, %DateTime{}} = Drowzee.SleepChecker.parse_time("10:45am", "Australia/Sydney")
     assert {:ok, %DateTime{}} = Drowzee.SleepChecker.parse_time("02:30pm", "Australia/Sydney")
+  end
+  
+  test "parses a valid time in 24-hour format" do
+    assert {:ok, dt} = Drowzee.SleepChecker.parse_time("00:00", "Australia/Sydney")
+    assert dt.hour == 0
+    assert dt.minute == 0
+    
+    assert {:ok, dt} = Drowzee.SleepChecker.parse_time("10:45", "Australia/Sydney")
+    assert dt.hour == 10
+    assert dt.minute == 45
+    
+    assert {:ok, dt} = Drowzee.SleepChecker.parse_time("14:30", "Australia/Sydney")
+    assert dt.hour == 14
+    assert dt.minute == 30
+    
+    assert {:ok, dt} = Drowzee.SleepChecker.parse_time("23:59", "Australia/Sydney")
+    assert dt.hour == 23
+    assert dt.minute == 59
   end
 
   test "fails to parse an invalid time" do
@@ -15,13 +33,29 @@ defmodule Drowzee.SleepCheckerTest do
     assert {:error, "Expected `minute` at line 1, column 4."} = Drowzee.SleepChecker.parse_time("12:65am", "Australia/Sydney")
   end
 
-  test "returns true when it's naptime" do
+  test "returns true when it's naptime with 12-hour format" do
     # Very lazy way to write this test
     assert Drowzee.SleepChecker.naptime?("12:00am", "11:59pm", "Australia/Sydney")
   end
 
-  test "returns false when it's not naptime" do
+  test "returns false when it's not naptime with 12-hour format" do
     # Very lazy way to write this test
     assert !Drowzee.SleepChecker.naptime?("11:58pm", "11:59pm", "Australia/Sydney")
+  end
+  
+  test "returns true when it's naptime with 24-hour format" do
+    assert Drowzee.SleepChecker.naptime?("00:00", "23:59", "Australia/Sydney")
+  end
+
+  test "returns false when it's not naptime with 24-hour format" do
+    assert !Drowzee.SleepChecker.naptime?("23:58", "23:59", "Australia/Sydney")
+  end
+  
+  test "works with mixed formats" do
+    # 12-hour sleep time, 24-hour wake time
+    assert Drowzee.SleepChecker.naptime?("12:00am", "23:59", "Australia/Sydney")
+    
+    # 24-hour sleep time, 12-hour wake time
+    assert !Drowzee.SleepChecker.naptime?("23:58", "11:59pm", "Australia/Sydney")
   end
 end


### PR DESCRIPTION
## New Features
- Added support for 24-hour time format (HH:MM) alongside the existing 12-hour format (H:MMam/pm)
- Implemented smart time parsing that tries 24-hour format first, then falls back to 12-hour format
- Updated CRD documentation to reflect the new supported time formats
- Added comprehensive test coverage for the new time format

## Technical Details
- The `parse_time` function now attempts to parse input using 24-hour format first
- If 24-hour parsing fails, it falls back to the existing 12-hour AM/PM format
- Both formats can be used interchangeably within the same schedule (e.g., sleep time in 24h, wake time in 12h)
- The system automatically detects which format is being used and parses it accordingly

## Benefits
- Improved user experience for regions where 24-hour time is the standard
- More flexibility in how times can be specified
- Backward compatibility with existing schedules using 12-hour format
- No configuration changes needed - the system automatically detects the format

## Testing
- Added tests for parsing times in 24-hour format
- Added tests for the naptime? function with 24-hour format
- Added tests for mixed format usage (24h and 12h in the same schedule)