### PR TITLE
Auto-removal of Manual Overrides when Schedule State Aligns

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 ###### Build Image ######
 #########################
 
-FROM elixir:1.18 AS builder
+FROM elixir:1.18.3 AS builder
 
 ENV MIX_ENV=prod \
   MIX_HOME=/opt/mix \
@@ -40,7 +40,7 @@ RUN mix release
 ##### Release Image #####
 #########################
 
-FROM elixir:1.18-slim
+FROM elixir:1.18.3-slim
 
 # set runner ENV
 ENV MIX_ENV=prod

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/mix.exs
+++ b/mix.exs
@@ -57,6 +57,7 @@ defmodule Drowzee.MixProject do
       {:dns_cluster, "~> 0.1.1"},
       {:bandit, "~> 1.5"},
       {:bonny, "~> 1.0"},
+      {:inflex, "~> 2.0.0", override: true},
       {:timex, "~> 3.7"},
       {:crontab, "~> 1.1"}
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Drowzee.MixProject do
     [
       app: :drowzee,
       version: "0.1.0",
-      elixir: "~> 1.14",
+      elixir: "~> 1.18",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       consolidate_protocols: Mix.env() != :dev,
@@ -57,7 +57,6 @@ defmodule Drowzee.MixProject do
       {:dns_cluster, "~> 0.1.1"},
       {:bandit, "~> 1.5"},
       {:bonny, "~> 1.0"},
-      {:inflex, "~> 2.0.0", override: true},
       {:timex, "~> 3.7"},
       {:crontab, "~> 1.1"}
     ]


### PR DESCRIPTION
# Auto-removal of Manual Overrides when Schedule State Aligns

## Summary

This PR enhances the manual override functionality in Drowzee by automatically removing overrides when they align with the schedule's natural state. This improves user experience by eliminating the need for manual cleanup of overrides that are no longer necessary.

## Problem

Currently, manual overrides persist indefinitely until a user explicitly removes them, even when the schedule's natural state has caught up with the override state. This creates unnecessary maintenance overhead for users who need to remember to remove overrides.

## Solution

The solution automatically clears manual overrides in two specific scenarios:

1. When a schedule has a manual sleep override and it's naturally naptime
2. When a schedule has a manual wake-up override and it's naturally not naptime (wake time)

This maintains the core functionality of manual overrides while making them more intuitive and less maintenance-heavy for users.

## Implementation Details

- Added two new case clauses in the `update_state` function to detect when a manual override matches the natural schedule state
- Added a helper function `remove_manual_override/1` that calls the existing `Drowzee.K8s.remove_override/1` function
- Updated comments to better reflect the behavior of each case clause
- Maintained the priority of initial override actions over auto-removal to ensure manual actions are always executed first

## Testing

- Manually tested by creating sleep schedules with manual overrides and verifying they are automatically removed when the schedule time aligns with the override state
- Verified that manual overrides are still respected when they differ from the natural schedule state
- Confirmed that the system returns to schedule-based operation after auto-removal

## Screenshots

N/A

## Checklist

- [x] Code follows the project's coding style
- [x] Documentation has been updated (comments in code)
- [x] Changes have been manually tested
- [x] No new warnings are generated
- [x] Existing functionality is not broken